### PR TITLE
Upgrading Agent to Support Passenger 5

### DIFF
--- a/.octopolo.yml
+++ b/.octopolo.yml
@@ -1,2 +1,2 @@
 deploy_branch: master
-github_repo: sportngin/newrelic_passenger_status_plugin
+github_repo: sportngin/newrelic_passenger_stats_plugin

--- a/.octopolo.yml
+++ b/.octopolo.yml
@@ -1,0 +1,2 @@
+deploy_branch: master
+github_repo: sportngin/newrelic_passenger_status_plugin

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+branches:
+  only:
+    - master
+script: bundle exec rspec
+language: ruby
+bundler_args: --without development --deployment --jobs=3 --retry=3
+cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,5 @@ gem "newrelic_plugin"
 gem "passenger"
 
 group :test, :development do
-  gem "yaml"
   gem "rspec"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source "http://rubygems.org"
 gem "newrelic_plugin"
-gem "passenger", "~> 3.0.0"
+gem "passenger"
+
+group :test, :development do
+  gem "rspec"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ gem "newrelic_plugin"
 gem "passenger"
 
 group :test, :development do
+  gem "yaml"
   gem "rspec"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,33 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    daemon_controller (1.1.8)
-    fastthread (1.0.7)
-    json (1.8.1)
+    diff-lcs (1.2.5)
+    json (1.8.2)
     newrelic_plugin (1.3.1)
       json
-    passenger (3.0.21)
-      daemon_controller (>= 1.0.0)
-      fastthread (>= 1.0.1)
+    passenger (5.0.7)
       rack
       rake (>= 0.8.1)
-    rack (1.5.2)
-    rake (10.1.1)
+    rack (1.6.1)
+    rake (10.4.2)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.3)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-mocks (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-support (3.2.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   newrelic_plugin
-  passenger (~> 3.0.0)
+  passenger
+  rspec

--- a/config/template_newrelic_plugin.yml
+++ b/config/template_newrelic_plugin.yml
@@ -21,7 +21,7 @@ agents:
     ssh_command: ssh -l username
     passenger_status_command: passenger-status
     # the hostnames for your app instances
-    # - the agent will ssh into these to run `passenger-status` and `passenger-memory-stats`
+    # - the agent will ssh into these to run `passenger-status`
     app_hostnames:
       - foo1.bar.com
       - foo2.bar.com

--- a/lib/passenger_status_aggregator.rb
+++ b/lib/passenger_status_aggregator.rb
@@ -62,10 +62,10 @@ class PassengerStatusAggregator
   end
 
   def cpu
-    stats.map{|host,stats| stats[:cpu]}.reduce(:+)
+    stats.map{|host,stats| stats[:cpu]}.reduce(:+) / stats.keys.count
   end
 
   def memory
-    stats.map{|host,stats| stats[:memory]}.reduce(:+)
+    stats.map{|host,stats| stats[:memory]}.reduce(:+) / stats.keys.count
   end
 end

--- a/lib/passenger_status_parser.rb
+++ b/lib/passenger_status_parser.rb
@@ -39,4 +39,28 @@ class PassengerStatusParser
     queued ? queued[1].to_i : 0
   end
 
+  def memory
+    if memory = output.scan(/Memory\s\s:\s+(\d+)/).flatten.map(&:to_i).reduce(:+)
+      memory.to_f/booted.to_f
+    else
+      0.0
+    end
+  end
+
+  def cpu
+    if cpu = output.scan(/CPU:\s+(\d+)/).flatten.map(&:to_i).reduce(:+)
+      cpu.to_f/booted.to_f
+    else
+      0.0
+    end
+  end
+
+  def to_hash
+    parsed = {
+      :active => active, :inactive => inactive,
+      :max => max, :booted => booted, :queued => queued,
+      :memory => memory, :cpu => cpu
+    }
+  end
+
 end

--- a/lib/passenger_status_parser.rb
+++ b/lib/passenger_status_parser.rb
@@ -1,0 +1,42 @@
+class PassengerStatusParser
+
+  attr_accessor :output
+
+  def initialize(output)
+    @output = output
+  end
+
+  def active
+    if active = output.match(/active\s+=\s+(\d+)/)
+      active[1].to_i
+    elsif active = output.scan(/Sessions:\s+(\d+)/).flatten.map(&:to_i).reduce(:+)
+      active
+    else
+      0
+    end
+  end
+
+  def inactive
+    if inactive = output.match(/inactive\s+=\s+(\d+)/)
+      inactive[1].to_i
+    else
+      booted - active
+    end
+  end
+
+  def max
+    max = output.match(/max\s+=\s+(\d+)/) || output.match(/Max pool size\s+:\s+(\d+)/)
+    max ? max[1].to_i : 0 
+  end
+
+  def booted
+    booted = output.match(/count\s+=\s+(\d+)/) || output.match(/Processes\s+:\s+(\d+)/)
+    booted ? booted[1].to_i : 0
+  end
+
+  def queued
+    queued = output.match(/Waiting on global queue:\s+(\d+)/) || output.match(/Requests in queue:\s+(\d+)/)
+    queued ? queued[1].to_i : 0
+  end
+
+end

--- a/newrelic_passenger_stats_agent
+++ b/newrelic_passenger_stats_agent
@@ -31,10 +31,10 @@ module PassengerStatsAgent
     private
 
     def record_passenger_status_metrics(aggregator)
-      report_metric "passenger_stats.processes.max", "Processes", aggregator.stats[:max]
-      report_metric "passenger_stats.processes.booted", "Processes", aggregator.stats[:booted]
-      report_metric "passenger_stats.processes.active", "Processes", aggregator.stats[:active]
-      report_metric "passenger_stats.queue.waiting", "Requests", aggregator.stats[:queued]
+      report_metric "passenger_stats.processes.max", "Processes", aggregator.max
+      report_metric "passenger_stats.processes.booted", "Processes", aggregator.booted
+      report_metric "passenger_stats.processes.active", "Processes", aggregator.active
+      report_metric "passenger_stats.queue.waiting", "Requests", aggregator.queued
       report_metric "passenger_stats.aggregate.capacity", "Capacity", aggregator.capacity
     end
 

--- a/newrelic_passenger_stats_agent
+++ b/newrelic_passenger_stats_agent
@@ -31,11 +31,13 @@ module PassengerStatsAgent
     private
 
     def record_passenger_status_metrics(aggregator)
-      report_metric "passenger_stats.processes.max", "Processes", aggregator.max
-      report_metric "passenger_stats.processes.booted", "Processes", aggregator.booted
-      report_metric "passenger_stats.processes.active", "Processes", aggregator.active
-      report_metric "passenger_stats.queue.waiting", "Requests", aggregator.queued
-      report_metric "passenger_stats.aggregate.capacity", "Capacity", aggregator.capacity
+      report_metric "passenger_stats.aggregate.max", "Processes", aggregator.max
+      report_metric "passenger_stats.aggregate.booted", "Processes", aggregator.booted
+      report_metric "passenger_stats.aggregate.active", "Processes", aggregator.active
+      report_metric "passenger_stats.aggregate.queued", "Requests", aggregator.queued
+      report_metric "passenger_stats.aggregate.capacity", "Percent", aggregator.capacity
+      report_metric "passenger_stats.aggregate.cpu", "Percent", aggregator.cpu
+      report_metric "passenger_stats.aggregate.memory", "Megabytes", aggregator.memory
     end
 
   end

--- a/newrelic_passenger_stats_agent
+++ b/newrelic_passenger_stats_agent
@@ -11,7 +11,7 @@ module PassengerStatsAgent
   class Agent < NewRelic::Plugin::Agent::Base
 
     agent_guid "com.sportngin.passenger-stats-agent"
-    agent_version "0.0.5"
+    agent_version "0.1.0"
     agent_config_options :app_name, :ssh_command, :passenger_status_command, :app_hostnames
     agent_human_labels("Passenger Stats") { "Passenger Stats for #{app_name}" }
 

--- a/newrelic_passenger_stats_agent
+++ b/newrelic_passenger_stats_agent
@@ -2,7 +2,6 @@
 
 require "rubygems"
 require "bundler/setup"
-
 require "newrelic_plugin"
 
 require File.join(File.dirname(__FILE__), 'lib/passenger_status_aggregator')
@@ -12,7 +11,7 @@ module PassengerStatsAgent
   class Agent < NewRelic::Plugin::Agent::Base
 
     agent_guid "com.sportngin.passenger-stats-agent"
-    agent_version "0.0.4"
+    agent_version "0.0.5"
     agent_config_options :app_name, :ssh_command, :passenger_status_command, :app_hostnames
     agent_human_labels("Passenger Stats") { "Passenger Stats for #{app_name}" }
 
@@ -25,7 +24,7 @@ module PassengerStatsAgent
         :ssh_command => ssh_command,
         :passenger_status_command => passenger_status_command,
       }
-      aggregator = PassengerStatusAggregator.new(options)
+      aggregator = PassengerStatusAggregator.new(options).run
       record_passenger_status_metrics(aggregator)
     end
 
@@ -36,7 +35,7 @@ module PassengerStatsAgent
       report_metric "passenger_stats.processes.booted", "Processes", aggregator.stats[:booted]
       report_metric "passenger_stats.processes.active", "Processes", aggregator.stats[:active]
       report_metric "passenger_stats.queue.waiting", "Requests", aggregator.stats[:queued]
-      report_metric "passenger_stats.aggregate.capacity", "Capacity", aggregator.percent_capacity
+      report_metric "passenger_stats.aggregate.capacity", "Capacity", aggregator.capacity
     end
 
   end

--- a/spec/passenger_spec_helper.rb
+++ b/spec/passenger_spec_helper.rb
@@ -26,7 +26,7 @@ Instance: qHjiiRNe (nginx/1.8.0 Phusion_Passenger/5.0.7)
 
 ----------- General information -----------
 Max pool size : 2
-Processes     : 1
+Processes     : 2
 Requests in top-level queue : 0
 
 ----------- Application groups -----------

--- a/spec/passenger_spec_helper.rb
+++ b/spec/passenger_spec_helper.rb
@@ -1,0 +1,70 @@
+module PassengerSpecHelper
+  def self.v3_response 
+    response =<<EOF 
+----------- General information -----------
+max      = 4
+count    = 4
+active   = 0
+inactive = 4
+Waiting on global queue: 0
+
+----------- Application groups -----------
+/srv/www/ngin/current:
+  App root: /srv/www/ngin/current
+  * PID: 18198   Sessions: 0    Processed: 127     Uptime: 3m 51s
+  * PID: 18189   Sessions: 0    Processed: 152     Uptime: 3m 51s
+  * PID: 18206   Sessions: 0    Processed: 97      Uptime: 3m 51s
+  * PID: 18181   Sessions: 0    Processed: 67      Uptime: 4m 34s
+EOF
+  end
+
+  def self.v5_response 
+    response =<<EOF 
+Version : 5.0.7
+Date    : 2015-05-07 11:32:16 -0700
+Instance: qHjiiRNe (nginx/1.8.0 Phusion_Passenger/5.0.7)
+
+----------- General information -----------
+Max pool size : 2
+Processes     : 1
+Requests in top-level queue : 0
+
+----------- Application groups -----------
+/srv/www/stat_ngin/current/public (staging)#default:
+  App root: /srv/www/stat_ngin/current
+  Requests in queue: 3
+  * PID: 11169   Sessions: 0       Processed: 74      Uptime: 1m 18s
+    CPU: 2%      Memory  : 71M     Last used: 0s ago
+  * PID: 11460   Sessions: 1       Processed: 0       Uptime: 11s
+    CPU: 0%      Memory  : 14M     Last used: 11s ago
+EOF
+  end
+
+  def self.plugin_yaml
+    response =<<EOF
+newrelic:
+  #
+  # Update with your New Relic account license key:
+  #
+  license_key: 'YOUR_LICENSE_KEY_HERE'
+  #
+  # Set to '1' for verbose output, remove for normal output.
+  # All output goes to stdout/stderr.
+  #
+  # verbose: 1
+#
+# Agent Configuration:
+#
+agents:
+  passenger_stats:
+    app_name: my_app
+    ssh_command: ssh -l username
+    passenger_status_command: passenger-status
+    # the hostnames for your app instances
+    # - the agent will ssh into these to run `passenger-status` and `passenger-memory-stats`
+    app_hostnames:
+      - foo1.bar.com
+      - foo2.bar.com
+EOF
+  end
+end

--- a/spec/passenger_status_aggregator_spec.rb
+++ b/spec/passenger_status_aggregator_spec.rb
@@ -1,0 +1,90 @@
+require 'passenger_status_aggregator'
+require 'spec_helper'
+
+describe PassengerStatusAggregator do 
+  let(:v5_response) {PassengerSpecHelper.v5_response}
+  let(:v3_response) {PassengerSpecHelper.v3_response} 
+  let(:plugin_yaml) {PassengerSpecHelper.plugin_yaml}
+  let(:options) do 
+    {
+      :ssh_command => "ssh command", 
+      :app_hostnames => ["foo1.bar.com","foo2.bar.com"], 
+      :passenger_status_command => "passenger status"
+    }
+  end
+  let(:stats) do
+    {
+      :max => 0,
+      :booted => 0,
+      :active => 0,
+      :inactive => 0,
+      :queued => 0,
+    }
+  end
+
+  subject {PassengerStatusAggregator.new(options)}
+
+  context "#initialize" do
+    it "should set instance variables properly" do
+      expect(subject.stats).to eq (stats)
+      expect(subject.instance_variable_get(:@ssh_command)).to eq("ssh command")
+      expect(subject.instance_variable_get(:@app_hostnames)).to eq(["foo1.bar.com","foo2.bar.com"])
+      expect(subject.instance_variable_get(:@passenger_status_command)).to eq("passenger status")
+    end
+  end
+
+  context "#app_hostnames" do
+    it "should return the correct hostnames from YAML" do
+      yaml = YAML.load(plugin_yaml)
+      filepath = "config/newrelic_plugin.yml"
+      allow(YAML).to receive(:load_file).with(filepath).and_return(yaml)
+      expect(subject.app_hostnames).to eq(options[:app_hostnames])
+    end
+  end
+
+  context "#run" do
+    it "call #collect_stats on each hostname" do
+      allow(subject).to receive(:app_hostnames).and_return(options[:app_hostnames])
+      expect(subject).to receive(:collect_stats).with("foo1.bar.com")
+      expect(subject).to receive(:collect_stats).with("foo2.bar.com")
+      subject.run
+    end
+  end
+
+  context "#capacity" do
+    subject {PassengerStatusAggregator.new(options)}
+
+    it "returns a percentage" do
+      subject.stats[:max] = 10
+      subject.stats[:active] = 4
+      expect(subject.capacity).to eq(40.0)
+    end
+  end
+
+  context "parse_output" do
+    let(:parser) {double()}
+    before do
+      allow(parser).to receive(:active) {2}
+      allow(parser).to receive(:inactive) {4}
+      allow(parser).to receive(:max) {6}
+      allow(parser).to receive(:booted) {8}
+      allow(parser).to receive(:queued) {10}
+    end
+
+    it "calls PassengerStatusParser.new" do
+      expect(PassengerStatusParser).to receive(:new).with(v5_response).and_return(parser)
+      subject.parse_output(v5_response)
+    end
+
+    it "increments active, inactive, max, booted, queued" do
+      allow(PassengerStatusParser).to receive(:new).with(v5_response).and_return(parser)
+      expect(parser).to receive(:active)
+      expect(parser).to receive(:inactive)
+      expect(parser).to receive(:max)
+      expect(parser).to receive(:booted)
+      expect(parser).to receive(:queued)
+      subject.parse_output(v5_response)
+    end
+  end
+
+end

--- a/spec/passenger_status_aggregator_spec.rb
+++ b/spec/passenger_status_aggregator_spec.rb
@@ -12,21 +12,12 @@ describe PassengerStatusAggregator do
       :passenger_status_command => "passenger status"
     }
   end
-  let(:stats) do
-    {
-      :max => 0,
-      :booted => 0,
-      :active => 0,
-      :inactive => 0,
-      :queued => 0,
-    }
-  end
 
   subject {PassengerStatusAggregator.new(options)}
 
   context "#initialize" do
     it "should set instance variables properly" do
-      expect(subject.stats).to eq (stats)
+      expect(subject.stats).to eq ({})
       expect(subject.instance_variable_get(:@ssh_command)).to eq("ssh command")
       expect(subject.instance_variable_get(:@app_hostnames)).to eq(["foo1.bar.com","foo2.bar.com"])
       expect(subject.instance_variable_get(:@passenger_status_command)).to eq("passenger status")
@@ -55,35 +46,21 @@ describe PassengerStatusAggregator do
     subject {PassengerStatusAggregator.new(options)}
 
     it "returns a percentage" do
-      subject.stats[:max] = 10
-      subject.stats[:active] = 4
+      subject.stats[:"foo1.bar.com"] = {
+        :max => 10,
+        :active => 4
+      }
       expect(subject.capacity).to eq(40.0)
     end
   end
 
   context "parse_output" do
     let(:parser) {double()}
-    before do
-      allow(parser).to receive(:active) {2}
-      allow(parser).to receive(:inactive) {4}
-      allow(parser).to receive(:max) {6}
-      allow(parser).to receive(:booted) {8}
-      allow(parser).to receive(:queued) {10}
-    end
 
-    it "calls PassengerStatusParser.new" do
+    it "calls PassengerStatusParser.new and to_hash" do
       expect(PassengerStatusParser).to receive(:new).with(v5_response).and_return(parser)
-      subject.parse_output(v5_response)
-    end
-
-    it "increments active, inactive, max, booted, queued" do
-      allow(PassengerStatusParser).to receive(:new).with(v5_response).and_return(parser)
-      expect(parser).to receive(:active)
-      expect(parser).to receive(:inactive)
-      expect(parser).to receive(:max)
-      expect(parser).to receive(:booted)
-      expect(parser).to receive(:queued)
-      subject.parse_output(v5_response)
+      expect(parser).to receive(:to_hash)
+      subject.parse_output("bar",v5_response)
     end
   end
 

--- a/spec/passenger_status_aggregator_spec.rb
+++ b/spec/passenger_status_aggregator_spec.rb
@@ -64,4 +64,52 @@ describe PassengerStatusAggregator do
     end
   end
 
+  context "results" do
+    subject {PassengerStatusAggregator.new(options)}
+    before do
+      subject.stats["foo1.bar.com"] = {
+        :max => 10,
+        :active => 4,
+        :booted => 6,
+        :queued => 0,
+        :cpu => 4.0,
+        :memory => 100
+      }
+      subject.stats["foo2.bar.com"] = {
+        :max => 10,
+        :active => 4,
+        :booted => 6,
+        :queued => 10,
+        :cpu => 1.0,
+        :memory => 40
+      }
+    end
+
+    context "#max" do
+      it "gets the correct result" do
+        expect(subject.max).to eq(20)
+      end
+    end
+    context "#active" do
+      it "gets the correct result" do
+        expect(subject.active).to eq(8)
+      end
+    end
+    context "#queued" do
+      it "gets the correct result" do
+        expect(subject.queued).to eq(10)
+      end
+    end
+    context "#cpu" do
+      it "gets the correct result" do
+        expect(subject.cpu).to eq(2.5)
+      end
+    end
+    context "#memory" do
+      it "gets the correct result" do
+        expect(subject.memory).to eq(70)
+      end
+    end
+  end
+
 end

--- a/spec/passenger_status_parser_spec.rb
+++ b/spec/passenger_status_parser_spec.rb
@@ -37,6 +37,30 @@ describe PassengerStatusParser do
       end
     end
 
+    context "#cpu" do
+      it "returns the right value" do
+        expect(subject.cpu).to eq(0.0)
+      end
+    end
+
+    context "#memory" do
+      it "returns the right value" do 
+        expect(subject.memory).to eq(0.0)
+      end
+    end
+
+    context "#to_hash" do 
+      let (:parsed) do 
+        {
+          :active => 0, :inactive => 4,
+          :max => 4, :booted => 4, :queued => 0,
+          :memory => 0.0, :cpu => 0.0
+        }
+      end
+      it "returns the right value" do 
+        expect(subject.to_hash).to eq(parsed)
+      end
+    end
   end
 
   context "Passenger 5" do
@@ -49,7 +73,7 @@ describe PassengerStatusParser do
 
     context "#inactive" do
       it "returns the right value" do
-        expect(subject.inactive).to eq(0)
+        expect(subject.inactive).to eq(1)
       end
     end
 
@@ -61,13 +85,38 @@ describe PassengerStatusParser do
 
     context "#booted" do
       it "returns the right value" do
-        expect(subject.booted).to eq(1)
+        expect(subject.booted).to eq(2)
       end
     end
 
     context "#queued" do
       it "returns the right value" do
         expect(subject.queued).to eq(3)
+      end
+    end
+
+    context "#cpu" do
+      it "returns the right value" do
+        expect(subject.cpu).to eq(1.0)
+      end
+    end
+
+    context "#memory" do
+      it "returns the right value" do 
+        expect(subject.memory).to eq(42.5)
+      end
+    end
+
+    context "#to_hash" do 
+      let (:parsed) do 
+        {
+          :active => 1, :inactive => 1,
+          :max => 2, :booted => 2, :queued => 3,
+          :memory => 42.5, :cpu => 1.0
+        }
+      end
+      it "returns the right value" do 
+        expect(subject.to_hash).to eq(parsed)
       end
     end
   end

--- a/spec/passenger_status_parser_spec.rb
+++ b/spec/passenger_status_parser_spec.rb
@@ -1,0 +1,108 @@
+require 'passenger_status_aggregator'
+require 'spec_helper'
+
+describe PassengerStatusParser do
+  let(:v5_response) {PassengerSpecHelper.v5_response}
+  let(:v3_response) {PassengerSpecHelper.v3_response} 
+  context "Passenger 3/4" do
+    subject {PassengerStatusParser.new(v3_response)}
+
+    context "#active" do
+      it "returns the right value" do
+        expect(subject.active).to eq(0)
+      end
+    end
+
+    context "#inactive" do
+      it "returns the right value" do
+        expect(subject.inactive).to eq(4)
+      end
+    end
+
+    context "#max" do
+      it "returns the right value" do
+        expect(subject.max).to eq(4)
+      end
+    end
+
+    context "#booted" do
+      it "returns the right value" do
+        expect(subject.booted).to eq(4)
+      end
+    end
+
+    context "#queued" do
+      it "returns the right value" do
+        expect(subject.queued).to eq(0)
+      end
+    end
+
+  end
+
+  context "Passenger 5" do
+    subject {PassengerStatusParser.new(v5_response)}
+    context "#active" do
+      it "returns the right value" do
+        expect(subject.active).to eq(1)
+      end
+    end
+
+    context "#inactive" do
+      it "returns the right value" do
+        expect(subject.inactive).to eq(0)
+      end
+    end
+
+    context "#max" do
+      it "returns the right value" do
+        expect(subject.max).to eq(2)
+      end
+    end
+
+    context "#booted" do
+      it "returns the right value" do
+        expect(subject.booted).to eq(1)
+      end
+    end
+
+    context "#queued" do
+      it "returns the right value" do
+        expect(subject.queued).to eq(3)
+      end
+    end
+  end
+
+  context "No Output" do
+    subject {PassengerStatusParser.new("Foo Bar")}
+
+    context "#active" do
+      it "returns the right value" do
+        expect(subject.active).to eq(0)
+      end
+    end
+
+    context "#inactive" do
+      it "returns the right value" do
+        expect(subject.inactive).to eq(0)
+      end
+    end
+
+    context "#max" do
+      it "returns the right value" do
+        expect(subject.max).to eq(0)
+      end
+    end
+
+    context "#booted" do
+      it "returns the right value" do
+        expect(subject.booted).to eq(0)
+      end
+    end
+
+    context "#queued" do
+      it "returns the right value" do
+        expect(subject.queued).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,29 @@
+require 'passenger_spec_helper'
+require 'YAML'
+
+RSpec.configure do |config|
+  # rspec-expectations config goes here. You can use an alternate
+  # assertion/expectation library such as wrong or the stdlib/minitest
+  # assertions if you prefer.
+  config.expect_with :rspec do |expectations|
+    # This option will default to `true` in RSpec 4. It makes the `description`
+    # and `failure_message` of custom matchers include text for helper methods
+    # defined using `chain`, e.g.:
+    #     be_bigger_than(2).and_smaller_than(4).description
+    #     # => "be bigger than 2 and smaller than 4"
+    # ...rather than:
+    #     # => "be bigger than 2"
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  # rspec-mocks config goes here. You can use an alternate test double
+  # library (such as bogus or mocha) by changing the `mock_with` option here.
+  config.mock_with :rspec do |mocks|
+    # Prevents you from mocking or stubbing a method that does not exist on
+    # a real object. This is generally recommended, and will default to
+    # `true` in RSpec 4.
+    mocks.verify_partial_doubles = true
+  end
+
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'passenger_spec_helper'
-require 'YAML'
+require 'yaml'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
This updates the passenger stats plugin to work with Passenger 5, while maintaining support for Passenger 3.

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.
