### PR TITLE
Version 0.2.0: Json gem ver upgrade to 2.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 gem "newrelic_plugin"
-gem "json", '2.2.0'
+gem "json", '~> 2.2.0'
 gem "passenger"
 
 group :test, :development do

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "http://rubygems.org"
 gem "newrelic_plugin"
+gem "json", '2.2.0'
 gem "passenger"
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    json (1.8.2)
+    json (2.2.0)
     newrelic_plugin (1.3.1)
       json
     passenger (5.0.7)
@@ -28,6 +28,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  json (= 2.2.0)
   newrelic_plugin
   passenger
   rspec
+
+BUNDLED WITH
+   1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  json (= 2.2.0)
+  json (~> 2.2.0)
   newrelic_plugin
   passenger
   rspec

--- a/newrelic_passenger_stats_agent
+++ b/newrelic_passenger_stats_agent
@@ -11,7 +11,7 @@ module PassengerStatsAgent
   class Agent < NewRelic::Plugin::Agent::Base
 
     agent_guid "com.sportngin.passenger-stats-agent"
-    agent_version "0.1.3"
+    agent_version "0.2.0"
     agent_config_options :app_name, :ssh_command, :passenger_status_command, :app_hostnames
     agent_human_labels("Passenger Stats") { "Passenger Stats for #{app_name}" }
 


### PR DESCRIPTION
What
----------------------
Use json gem ver 2.2.0

Why
----------------------
json 1.x is not compatible with ruby 2.6

Deploy Plan
-----------
Merge the PR. tar zip it and then put it in `https://s3.amazonaws.com/sportngin-ops-files/newrelic_passenger_stats_plugin/` bucket

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] See https://github.com/sportngin/guardhouse-cookbooks/pull/352
